### PR TITLE
fix for .net core

### DIFF
--- a/src/EfCore.Shaman/ModelScanner/FullTableName.cs
+++ b/src/EfCore.Shaman/ModelScanner/FullTableName.cs
@@ -42,6 +42,6 @@ namespace EfCore.Shaman.ModelScanner
 
         public string TableName { get; }
         public string Schema { get; }
-        private static readonly IEqualityComparer<string> Comparer = StringComparer.InvariantCultureIgnoreCase;
+        private static readonly IEqualityComparer<string> Comparer = StringComparer.OrdinalIgnoreCase;
     }
 }


### PR DESCRIPTION
There is no StringComparer.InvariantCultureIgnoreCase in .net core 1.1 (seems to be implemented in 2.0) so this line breaks compilation for netcoreapp.

However, I can hardly believe any one using culture-dependent names in DB. 